### PR TITLE
Don't throw uninitialized constant when using the Gem by itself

### DIFF
--- a/lib/atdis/model.rb
+++ b/lib/atdis/model.rb
@@ -1,5 +1,6 @@
 require 'active_model'
 require 'date'
+require 'multi_json'
 
 module ATDIS
   module TypeCastAttributes


### PR DESCRIPTION
Fixes #36
