### PR TITLE
Upgrade activemodel to 4.x series

### DIFF
--- a/atdis.gemspec
+++ b/atdis.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "multi_json", "~> 1.7"
   spec.add_dependency "rest-client"
   spec.add_dependency "rgeo-geojson"
-  spec.add_dependency "activemodel", "~> 4"
+  spec.add_dependency "activemodel"
 end

--- a/atdis.gemspec
+++ b/atdis.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "multi_json", "~> 1.7"
   spec.add_dependency "rest-client"
   spec.add_dependency "rgeo-geojson"
-  spec.add_dependency "activemodel", "~> 3"
+  spec.add_dependency "activemodel", "~> 4"
 end


### PR DESCRIPTION
This is needed to be able to upgrade PlanningAlerts to Rails 4.x since
this gem is included in the PlanningAlerts bundle.
