### PR TITLE
Add CODEOWNERS with team-morph as default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners for this repository
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything in the repo
+* @OpenAustralia/team-morph


### PR DESCRIPTION
## Description

Adds a `.github/CODEOWNERS` file naming `@OpenAustralia/team-morph` as the default owner for everything in the repository.

## Motivation and Context

The open modernisation PR stack in this repo currently has no automatic reviewer assignment. With CODEOWNERS on `main`, GitHub will request a review from `@OpenAustralia/team-morph` on every pull request. **Merge this before the modernisation stack** so reviewers are triggered as the stacked PRs retarget onto `main`.

Note: `team-morph` has been granted write access to this repository (required for CODEOWNERS review requests to take effect).

## How Has This Been Tested?

- [x] Checked affected area manually on my own / staging system — verified `@OpenAustralia/team-morph` exists and has push access via the GitHub API; CODEOWNERS syntax follows the GitHub documented format
- [ ] Ran automated tests on my own system (n/a — no code change)
- [ ] Confirmed it passed the GitHub actions tests

## Screenshots (if appropriate):

n/a

## Types of Changes

- [x] Documentation

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---

Assisted-by: opencode/anthropic.claude-fable-5
